### PR TITLE
Refactor: 將 `moveFocusIndex` 與 `moveFocusRules` 內的重複程式碼提取成一個共用的 `focusFirstElement` 函式，避免程式碼重複。

### DIFF
--- a/plugins/kb-focus.client.ts
+++ b/plugins/kb-focus.client.ts
@@ -1,3 +1,4 @@
+dart
 import { defineNuxtPlugin } from '#app';
 
 interface KbFocusData {
@@ -35,15 +36,23 @@ function focusElement(id: string | null) {
   currentId = id;
 }
 
-// moveFocus：Index 頁邏輯
-function moveFocusIndex(dir: 'up' | 'down' | 'left' | 'right') {
-  if (!currentId && !hasFocused && registry.size > 0) {
+// 聚焦第一個元素
+function focusFirstElement() {
+  if (!hasFocused && registry.size > 0) {
     const firstEntry = registry.values().next().value;
     if (firstEntry) {
       focusElement(firstEntry.id);
       hasFocused = true;
-      return;
+      return true;
     }
+  }
+  return false;
+}
+
+// moveFocus：Index 頁邏輯
+function moveFocusIndex(dir: 'up' | 'down' | 'left' | 'right') {
+  if (!currentId && focusFirstElement()) {
+    return;
   }
 
   if (!currentId) return;
@@ -88,13 +97,8 @@ function moveFocusIndex(dir: 'up' | 'down' | 'left' | 'right') {
 
 // moveFocus：Rules 頁邏輯（優先同軸）
 function moveFocusRules(dir: 'up' | 'down' | 'left' | 'right') {
-  if (!currentId && !hasFocused && registry.size > 0) {
-    const firstEntry = registry.values().next().value;
-    if (firstEntry) {
-      focusElement(firstEntry.id);
-      hasFocused = true;
-      return;
-    }
+  if (!currentId && focusFirstElement()) {
+    return;
   }
 
   if (!currentId) return;


### PR DESCRIPTION

# pull request 說明

## 變更內容
<!-- 請描述這個 PR 做了什麼變更 -->
- 程式碼小幅度重構：將 `moveFocusIndex` 與 `moveFocusRules` 內的重複程式碼提取成一個共用的 `focusFirstElement` 函式，避免程式碼重複。

## 相關議題
<!-- 請連結相關的 Issue，例如：Fixes #123 -->

## pull request 類型
<!-- 請選擇以下選項之一 -->
- [ ] 新功能 (New feature)
- [ ] 錯誤修復 (Bug fix)
- [ ] 文件更新 (Documentation update)
- [x] 程式碼重構 (Code refactoring)
- [ ] 效能優化 (Performance improvement)
- [ ] 測試相關 (Test related)
- [ ] 其他 (Other)

## 其他說明
<!-- 任何其他需要說明的內容 -->

## 檢查清單
- [x] 我的程式碼遵循專案的程式碼風格
- [x] 我已經測試過我的變更
- [x] 我已經更新相關文件
- [x] 我的變更不會產生新的警告
- [x] 我已經在本地測試過所有相關功能
