### PR TITLE
fix: 移除 schedule.vue 模板屬性中的無效 HTML 註解，修復 build 失敗

### DIFF
--- a/pages/rules/schedule.vue
+++ b/pages/rules/schedule.vue
@@ -16,15 +16,15 @@ const scheduleList = computed(() => {
   <div>
     <Disclosure
       v-for="(tab, index) in scheduleList"
-      :key="tab.id" <!-- 核心改動：使用 tab.id 作為 key，提供更穩定的識別 -->
+      :key="tab.id"
       v-slot="{ open }"
-      :default-open="index === 2" <!-- 保持原有的依賴索引的 default-open 邏輯 -->
+      :default-open="index === 2"
     >
       <DisclosureButton
         v-kb-focus="{
-          id: `rules-disclosure-2-${tab.id}`, <!-- 核心改動：使用 tab.id 建立更穩定的 DOM ID -->
+          id: `rules-disclosure-2-${tab.id}`,
           x: 2,
-          y: index + 30, <!-- 保持原有的依賴索引的 y 座標邏輯 -->
+          y: index + 30,
         }"
         class="w-full flex items-center justify-between p-6 border border-t-white border-b-white focus-border-item"
         :class="{ 'bg-primary-50 lg:bg-primary-500': open }"


### PR DESCRIPTION
## 變更內容

移除 `pages/rules/schedule.vue` 模板屬性區內的 4 個無效 HTML 註解（由 822a4df 引入）。Vue 不允許在標籤屬性區內擺放 `<!-- -->` 註解，導致 `nuxt build` 失敗（esbuild: Expected "}" but found "："）。

## 驗證

- 修正後在本地執行 `nuxt build` 成功（client + server 均建置完成）
- - 僅刪除註解文字，未更動任何邏輯
## pull request 類型

- [x] 錯誤修復 (Bug fix)